### PR TITLE
fix: clean up GUI layout with key file footer

### DIFF
--- a/.squad/agents/fox/history.md
+++ b/.squad/agents/fox/history.md
@@ -102,3 +102,14 @@ Full egui/eframe GUI implemented with 3-screen workflow (select → decrypt → 
 - **App state fields added:** `key_file_path: Option<PathBuf>`, `key_file_status: String`
 - **No citrust-core changes:** All changes confined to `crates/citrust-gui/src/main.rs`
 - **Verification:** `cargo build -p citrust-gui` ✅, `cargo clippy -p citrust-gui -- -D warnings` ✅ (zero warnings)
+
+### 2026-07: GUI Layout Cleanup — Key Footer Refactor
+- **Task:** Moved key file section from inline in `show_select_file_screen` to a persistent `TopBottomPanel::bottom()` footer visible on all screens.
+- **Changes:**
+  - Registered custom `TextStyle::Name("Small")` at 16px in the style setup alongside existing text styles.
+  - Removed separator and key file UI block from `show_select_file_screen` — the select screen is now a clean centered flow: heading → Select ROM → selected file + Decrypt.
+  - Created `show_key_footer()` method rendering a slim 36px bottom panel with muted gray (140) key status text on the left and a frameless "Browse…" link-button on the right.
+  - Footer renders before `CentralPanel` in the `update()` method so it appears on SelectFile, Decrypting, and Done screens.
+  - All existing functionality preserved: auto-detect on startup, Browse dialog with validation, hover tooltip for full path, key file path passed to decryption thread.
+- **Design insight:** `TopBottomPanel` must be added before `CentralPanel` in egui's immediate mode — egui allocates panel space in call order. The footer claims its 36px first, then CentralPanel fills the remainder.
+- **Verification:** `cargo build -p citrust-gui` ✅, `cargo clippy -p citrust-gui -- -D warnings` ✅, `cargo fmt --check -p citrust-gui` ✅

--- a/.squad/decisions/inbox/fox-gui-cleanup.md
+++ b/.squad/decisions/inbox/fox-gui-cleanup.md
@@ -1,0 +1,27 @@
+# GUI Layout: Key File Section → Footer Panel
+
+**By:** Fox (GUI Dev)  
+**Date:** 2026-07  
+**Status:** Implemented  
+**Category:** UI/UX
+
+## Decision
+
+Moved the key file indicator and Browse button from inline in the main select-file screen to a persistent `TopBottomPanel::bottom()` footer bar. The footer appears on all three screens (SelectFile, Decrypting, Done).
+
+## Rationale
+
+The inline key section with separator disrupted the clean centered ROM selection flow. The primary workflow (Select ROM → Decrypt) should be the visual hero; key file management is secondary configuration that users rarely change.
+
+## Implementation Details
+
+- **Footer:** 36px bottom panel, 16px "Small" text style, muted gray (`Color32::from_gray(140)`)
+- **Layout:** `🔑 Keys: {status}` label left-aligned, frameless "Browse…" button right-aligned
+- **Panel ordering:** Footer rendered before `CentralPanel` in `update()` — required by egui's immediate-mode space allocation
+- **No functionality changes:** Auto-detect, browse with validation, hover tooltip, decryption wiring all preserved
+
+## Impact
+
+- Only `crates/citrust-gui/src/main.rs` changed
+- No citrust-core or citrust-cli modifications
+- Custom `TextStyle::Name("Small")` registered at 16px for reuse in future subtle UI elements


### PR DESCRIPTION
## Problem

The key file section (separator + Browse button) added in PR #24 broke the clean centered layout of the select file screen.

## Solution

- Moved key file indicator to a persistent **36px bottom footer panel** using \TopBottomPanel::bottom()\
- Removed the separator that was splitting the main screen
- Key status shown in **muted gray 16px text** (new \Small\ text style)
- Browse button is now a **frameless link-style button** aligned right
- Footer appears on **all three screens** (select, decrypting, done)

## Result

Main screen is back to clean centered hero flow: heading → Select ROM → Decrypt. Key info is always visible but doesn't compete for attention.